### PR TITLE
Update link to builds

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
 
         <section id="downloads" class="clearfix">
           <a href="https://github.com/MassTransit/MassTransit" id="view-on-github" class="button"><span>View on GitHub</span></a>
-          <a href="http://teamcity.codebetter.com/project.html?projectId=project6&tab=projectOverview&guest=1" id="view-builds" class="button"><span>Builds in TeamCity</span></a>
+          <a href="https://ci.appveyor.com/project/phatboyg/masstransit" id="view-builds" class="button"><span>Builds in AppVeyor</span></a>
           <a href="http://www.nuget.org/packages?q=masstransit" id="view-packages" class="button"><span>NuGet Packages</span></a>
         </section>
 


### PR DESCRIPTION
Noticed that the link to the builds is pointing to Team City, and it looks like you're using AppVeyor now.
