### PR TITLE
Fixed the logo URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@ subtitle: Lightweight messaging framework for .NET
 
 <div class="cf mb5">
   <div class="fl w-20-ns">
-    <img src="http://docs.masstransit-project.com/en/latest/_images/mt-logo.png" style="margin-top:1rem;padding-top:1rem;"/>
+    <img src="https://raw.githubusercontent.com/MassTransit/MassTransit/develop/doc/source/mt-logo.png" style="margin-top:1rem;padding-top:1rem;"/>
   </div>
   <div class="fl w-40-ns">
     <p class="f5 lh-copy measure">MassTransit is a free, open source, lightweight message bus for creating distributed applications using the .NET framework. MassTransit provides an extensive set of features on top existing message transports, resulting in a developer friendly way to asynchronously connect services using message-based conversation patterns. Message-based communication is a reliable and scalable way to implement a service oriented architecture.</p>


### PR DESCRIPTION
Logo URL got broken after the ld docs site was taken down